### PR TITLE
feat: add Mailchimp free plan

### DIFF
--- a/public/images/providers/mailchimp.svg
+++ b/public/images/providers/mailchimp.svg
@@ -1,0 +1,999 @@
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="1000" height="268.89514" version="1.2" id="svg2" inkscape:version="0.48.5 r10040">
+ <metadata id="metadata1522">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>
+     image/svg+xml
+    </dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage">
+    </dc:type>
+    <dc:title>
+    </dc:title>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="1028" id="namedview1520" showgrid="false" fit-margin-top="0" fit-margin-left="0" fit-margin-right="0" fit-margin-bottom="0" inkscape:zoom="0.827497" inkscape:cx="612.75675" inkscape:cy="130.16439" inkscape:window-x="-8" inkscape:window-y="-8" inkscape:window-maximized="1" inkscape:current-layer="g46">
+ </sodipodi:namedview>
+ <desc id="desc4">
+  Created by HiQPdf
+ </desc>
+ <defs id="defs6">
+  <linearGradient gradientUnits="userSpaceOnUse" x1="21.799999" y1="173.28999" x2="5.0170002" y2="156.508" id="gradient1">
+   <stop offset="1e-07" stop-color="#00a0ff" stop-opacity="1" id="stop9">
+   </stop>
+   <stop offset="0.007" stop-color="#00a1ff" stop-opacity="1" id="stop11">
+   </stop>
+   <stop offset="0.26" stop-color="#00beff" stop-opacity="1" id="stop13">
+   </stop>
+   <stop offset="0.512" stop-color="#00d2ff" stop-opacity="1" id="stop15">
+   </stop>
+   <stop offset="0.76" stop-color="#00dfff" stop-opacity="1" id="stop17">
+   </stop>
+   <stop offset="1" stop-color="#00e3ff" stop-opacity="1" id="stop19">
+   </stop>
+  </linearGradient>
+  <linearGradient gradientUnits="userSpaceOnUse" x1="33.834" y1="161.99899" x2="9.6370001" y2="161.99899" id="gradient2">
+   <stop offset="1e-07" stop-color="#ffe000" stop-opacity="1" id="stop22">
+   </stop>
+   <stop offset="0.409" stop-color="#ffbd00" stop-opacity="1" id="stop24">
+   </stop>
+   <stop offset="0.775" stop-color="#ffa500" stop-opacity="1" id="stop26">
+   </stop>
+   <stop offset="1" stop-color="#ff9c00" stop-opacity="1" id="stop28">
+   </stop>
+  </linearGradient>
+  <linearGradient gradientUnits="userSpaceOnUse" x1="24.827" y1="159.70399" x2="2.069" y2="136.946" id="gradient3">
+   <stop offset="1e-07" stop-color="#ff3a44" stop-opacity="1" id="stop31">
+   </stop>
+   <stop offset="1" stop-color="#c31162" stop-opacity="1" id="stop33">
+   </stop>
+  </linearGradient>
+  <linearGradient gradientUnits="userSpaceOnUse" x1="7.2969999" y1="181.82401" x2="17.459999" y2="171.661" id="gradient4">
+   <stop offset="1e-07" stop-color="#32a071" stop-opacity="1" id="stop36">
+   </stop>
+   <stop offset="0.069" stop-color="#2da771" stop-opacity="1" id="stop38">
+   </stop>
+   <stop offset="0.476" stop-color="#15cf74" stop-opacity="1" id="stop40">
+   </stop>
+   <stop offset="0.801" stop-color="#06e775" stop-opacity="1" id="stop42">
+   </stop>
+   <stop offset="1" stop-color="#00f076" stop-opacity="1" id="stop44">
+   </stop>
+  </linearGradient>
+ </defs>
+ <g id="g46" style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:bevel" transform="translate(-30.000222,166.89645)">
+  <g stroke-miterlimit="2" id="g48" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g50" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g52" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g62" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g64" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g66" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g68" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g70" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g72" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g86" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g88" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(329,0)" id="g98" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g100" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g102" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g104" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g114" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g116" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g118" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g120" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g122" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g124" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g126" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g128" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g130" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g132" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g134" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g328" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g330" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g332" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g334" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g336" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g342" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g348" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g354" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g360" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g366" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g372" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g378" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g380" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g382" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g384" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g386" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g388" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g390" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g392" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g394" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g396" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g398" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g400" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g402" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g404" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g406" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g408" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g410" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g412" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g414" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g416" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g418" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(572,3484)" id="g420" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g422" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g424" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g426" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g468" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g470" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g472" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g474" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g476" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g482" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g484" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g486" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g488" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g490" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g492" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g494" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g496" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g498" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g500" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g502" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g504" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g506" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g508" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g510" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g512" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g514" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g516" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g518" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(485,3696)" id="g520" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g522" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g524" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g526" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g528" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g530" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g532" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g534" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g540" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g542" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g544" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g546" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g548" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g550" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g552" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g554" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g556" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g558" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g560" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g562" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g564" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g566" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g568" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g570" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g572" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g574" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g576" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(537,3697)" id="g578" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g580" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g582" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g584" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g586" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g588" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g590" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g592" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g598" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g600" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g602" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g604" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g606" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g608" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g610" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g612" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g614" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g616" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g618" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g620" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g622" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g624" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g626" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g628" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g630" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g632" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g634" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(590,3695)" id="g636" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g638" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g640" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g642" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g644" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g646" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g648" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g650" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(-120,3462)" id="g652" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(483,3696)" id="g654" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(483,3696)" id="g660" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(-120,3462)" id="g662" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g664" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g666" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g668" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g670" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g672" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g674" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g676" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g678" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g680" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(-120,3462)" id="g682" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(-120,3462)" id="g684" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g686" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g688" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g690" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g692" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g694" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g696" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g698" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g700" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g702" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g704" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g706" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g708" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g710" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(644,3696)" id="g712" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g714" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g716" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g718" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g720" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g722" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g724" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g726" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g732" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g734" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g736" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g738" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g740" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g742" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g744" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g746" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g748" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g750" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g752" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g754" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g756" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g758" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g760" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g762" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g764" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g766" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g768" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(695,3698)" id="g770" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g772" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g774" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g776" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g778" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g780" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g782" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g784" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.175,0,0,1.175,435.688,3789)" id="g786" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.175,0,0,1.175,435.688,3789)" id="g792" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.175,0,0,1.175,435.688,3789)" id="g798" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.175,0,0,1.175,435.688,3789)" id="g804" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.175,0,0,1.175,435.688,3789)" id="g810" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.175,0,0,1.175,435.688,3789)" id="g812" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.175,0,0,1.175,435.688,3789)" id="g814" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g816" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g818" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g820" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g822" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g824" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g826" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.175,0,0,1.175,435.688,3789)" id="g828" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.175,0,0,1.175,435.688,3789)" id="g830" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.175,0,0,1.175,435.688,3789)" id="g832" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g834" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g836" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g838" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g840" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g842" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g844" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g846" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g848" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g850" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g852" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(435,3789)" id="g854" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g856" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g858" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g860" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g862" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g864" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g866" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g868" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g870" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g876" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g882" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g892" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g898" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g904" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g906" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g912" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g914" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g920" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g922" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g928" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g930" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g932" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g938" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g940" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g942" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g944" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g946" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g948" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g950" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g952" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g954" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g960" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g962" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g964" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g966" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g968" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g970" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g972" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g974" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g976" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g982" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g984" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g986" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g988" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g990" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g992" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g994" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g996" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g998" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g1000" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1002" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1004" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1006" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g1008" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g1010" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g1012" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g1014" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g1016" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(1.17499,0,0,1.17499,605.688,3789)" id="g1018" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1020" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1022" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1024" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g1026" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g1028" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g1030" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1032" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1034" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1036" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g1038" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(605,3789)" id="g1040" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1042" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1044" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1046" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1060" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1062" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1064" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1066" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1068" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1070" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1072" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1074" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1076" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1078" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1080" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1082" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1088" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1090" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1092" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1094" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1102" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1104" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1106" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1108" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1110" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1112" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1134" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1136" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(329,0)" id="g1146" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1148" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1150" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1152" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1154" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1160" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1162" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1164" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1166" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1168" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1170" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1172" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1174" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1176" style="fill:#007c89;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1186" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1188" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.997198,0,0,0.997198,485.003,77)" id="g1190" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.997198,0,0,0.997198,485.003,77)" id="g1196" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.997198,0,0,0.997198,485.003,77)" id="g1198" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1200" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1202" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1204" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1206" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.997198,0,0,0.997198,485.003,77)" id="g1208" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1210" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1212" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1214" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1224" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1226" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.997198,0,0,0.997198,659.003,77)" id="g1228" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.997198,0,0,0.997198,659.003,77)" id="g1234" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.997198,0,0,0.997198,659.003,77)" id="g1236" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1238" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1240" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1242" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1244" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.997198,0,0,0.997198,659.003,77)" id="g1246" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1248" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1250" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1252" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1254" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(873,66)" id="g1256" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(873,66)" id="g1262" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(873,66)" id="g1264" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1266" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1268" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1270" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1272" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(239,0)" id="g1282" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1284" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1286" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1288" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1298" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1300" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(239,0)" id="g1310" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1312" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1314" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1316" style="fill:#241c15;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1322" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1324" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(873,66)" id="g1326" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1328" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1330" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1332" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(30,47)" id="g1334" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(30,47)" id="g1336" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1338" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1340" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 35.437,28.627 c 0.365,-0.044 0.715,-0.045 1.036,0 0.186,-0.427 0.218,-1.162 0.051,-1.962 -0.249,-1.19 -0.585,-1.91 -1.28,-1.798 -0.695,0.112 -0.721,0.974 -0.472,2.164 0.14,0.669 0.389,1.242 0.666,1.596 l -0.001,0" id="path1342" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1344" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1346" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 29.468,29.569 c 0.498,0.218 0.803,0.363 0.923,0.237 0.077,-0.079 0.054,-0.229 -0.065,-0.423 -0.245,-0.401 -0.751,-0.807 -1.286,-1.036 -1.096,-0.472 -2.403,-0.315 -3.411,0.41 -0.333,0.244 -0.648,0.582 -0.603,0.787 0.015,0.066 0.064,0.116 0.181,0.133 0.274,0.031 1.233,-0.453 2.338,-0.521 0.78,-0.048 1.426,0.196 1.923,0.414 l 0,-0.001" id="path1348" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1350" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1352" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 28.467,30.14 c -0.648,0.102 -1.005,0.316 -1.235,0.515 -0.196,0.171 -0.317,0.36 -0.316,0.493 l 0.05,0.118 0.107,0.041 c 0.146,0 0.474,-0.131 0.474,-0.131 0.902,-0.323 1.497,-0.284 2.086,-0.217 0.326,0.037 0.48,0.057 0.551,-0.055 0.021,-0.032 0.047,-0.101 -0.018,-0.207 -0.152,-0.246 -0.806,-0.662 -1.698,-0.556 l -0.001,-10e-4 0,0" id="path1354" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1356" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1358" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1360" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(5.3781948,0,0,5.3781948,-131.34682,-446.57018)" id="g1362" style="opacity:0;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+   <image x="56" y="73" width="4" height="6" preserveAspectRatio="none" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAGCAYAAADkOT91AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAO0lEQVR4nGNgwAKEGBgY3jAwMPjBBJQYGBj+MzAwbIEJsDAwMHxlYGC4h6xtNgMDw01kAV4GBgZzEAsAPqYGsWk1UZcAAAAASUVORK5CYII=" id="image1364" />
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1366" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1368" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1370" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1372" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(30,47)" id="g1374" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1376" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1378" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 33.422,32.236 c 0.44,0.216 0.924,0.131 1.082,-0.19 0.158,-0.321 -0.071,-0.756 -0.511,-0.972 -0.44,-0.216 -0.924,-0.131 -1.082,0.19 -0.158,0.321 0.071,0.756 0.511,0.972" id="path1380" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1382" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1384" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 36.25,29.765 c -0.357,-0.006 -0.654,0.386 -0.662,0.877 -0.008,0.49 0.275,0.892 0.632,0.898 0.357,0.006 0.654,-0.386 0.662,-0.876 0.008,-0.49 -0.275,-0.892 -0.632,-0.899 l 0,0" id="path1386" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1388" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1390" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 12.243,38.603 c -0.089,-0.111 -0.235,-0.077 -0.376,-0.045 -0.099,0.023 -0.211,0.049 -0.333,0.047 -0.263,-0.005 -0.486,-0.117 -0.611,-0.309 -0.163,-0.25 -0.153,-0.623 0.026,-1.05 l 0.084,-0.191 c 0.287,-0.643 0.766,-1.72 0.228,-2.745 -0.405,-0.772 -1.067,-1.253 -1.862,-1.354 -0.763,-0.097 -1.549,0.186 -2.05,0.739 -0.791,0.872 -0.914,2.059 -0.761,2.479 0.056,0.154 0.144,0.196 0.207,0.205 0.135,0.018 0.333,-0.08 0.458,-0.415 l 0.036,-0.109 c 0.056,-0.177 0.159,-0.507 0.328,-0.772 0.204,-0.319 0.522,-0.539 0.896,-0.619 0.38,-0.081 0.769,-0.009 1.094,0.204 0.554,0.363 0.767,1.041 0.531,1.689 -0.122,0.335 -0.321,0.975 -0.277,1.501 0.089,1.065 0.744,1.493 1.332,1.538 0.572,0.022 0.972,-0.3 1.073,-0.535 0.06,-0.139 0.009,-0.223 -0.023,-0.26 l 0,0.002 0,0" id="path1392" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1394" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1396" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="M 45.269,36.655 C 45.247,36.578 45.105,36.059 44.91,35.434 l -0.397,-1.065 c 0.782,-1.171 0.796,-2.218 0.692,-2.811 -0.111,-0.735 -0.417,-1.362 -1.034,-2.009 -0.617,-0.648 -1.878,-1.311 -3.651,-1.808 L 39.59,27.483 C 39.585,27.445 39.541,25.29 39.501,24.365 39.472,23.696 39.414,22.653 39.09,21.624 38.704,20.232 38.032,19.015 37.192,18.236 39.509,15.835 40.955,13.189 40.951,10.92 40.944,6.556 35.585,5.235 28.98,7.97 L 27.581,8.564 C 27.575,8.558 25.051,6.082 25.013,6.049 17.483,-0.519001 -6.062,25.651 1.466,32.007 l 1.645,1.394 c -0.427,1.105 -0.594,2.372 -0.457,3.734 0.176,1.749 1.078,3.426 2.541,4.722 1.388,1.23 3.214,2.009 4.985,2.007 2.929,6.751 9.622,10.892 17.47,11.125 8.418,0.25 15.485,-3.7 18.446,-10.796 0.194,-0.498 1.016,-2.742 1.016,-4.723 0,-1.991 -1.125,-2.816 -1.842,-2.816 l -0.001,10e-4 0,0 m -34.442,5.313 c -0.256,0.044 -0.517,0.061 -0.78,0.055 -2.543,-0.068 -5.289,-2.357 -5.562,-5.072 -0.302,-3 1.231,-5.31 3.946,-5.857 0.324,-0.065 0.717,-0.103 1.14,-0.081 1.521,0.083 3.762,1.251 4.274,4.564 0.453,2.934 -0.267,5.922 -3.018,6.391 l 0,0 M 7.988,29.299 C 6.298,29.628 4.809,30.585 3.898,31.908 3.354,31.454 2.339,30.575 2.16,30.233 0.706,27.472 3.747,22.104 5.871,19.073 11.121,11.581 19.343,5.911 23.15,6.939 c 0.619,0.175 2.668,2.551 2.668,2.551 0,0 -3.805,2.111 -7.333,5.054 -4.754,3.661 -8.346,8.981 -10.497,14.755 l 0,0 m 26.688,11.547 c 0.055,-0.023 0.093,-0.087 0.087,-0.149 -0.008,-0.077 -0.077,-0.133 -0.154,-0.125 0,0 -3.983,0.59 -7.746,-0.788 0.41,-1.332 1.5,-0.851 3.147,-0.718 2.969,0.177 5.63,-0.257 7.596,-0.821 1.704,-0.489 3.942,-1.453 5.681,-2.825 0.586,1.288 0.793,2.705 0.793,2.705 0,0 0.454,-0.081 0.833,0.152 0.358,0.221 0.621,0.679 0.442,1.865 -0.366,2.215 -1.307,4.012 -2.889,5.666 -0.963,1.037 -2.132,1.938 -3.47,2.593 -0.71,0.373 -1.467,0.696 -2.266,0.957 -5.964,1.948 -12.07,-0.194 -14.038,-4.793 -0.157,-0.346 -0.29,-0.708 -0.395,-1.086 -0.839,-3.031 -0.127,-6.667 2.099,-8.956 l 0,-0.001 c 0.137,-0.146 0.277,-0.317 0.277,-0.533 0,-0.181 -0.115,-0.371 -0.214,-0.506 -0.779,-1.129 -3.476,-3.054 -2.934,-6.779 0.389,-2.676 2.729,-4.56 4.911,-4.448 l 0.553,0.032 c 0.945,0.056 1.77,0.177 2.549,0.21 1.303,0.056 2.474,-0.133 3.861,-1.289 0.468,-0.39 0.843,-0.728 1.478,-0.836 0.067,-0.011 0.233,-0.071 0.564,-0.055 0.339,0.018 0.661,0.111 0.951,0.304 1.112,0.74 1.27,2.533 1.328,3.844 0.033,0.749 0.123,2.56 0.154,3.079 0.071,1.189 0.383,1.356 1.015,1.565 0.356,0.117 0.686,0.204 1.172,0.341 1.472,0.413 2.345,0.833 2.896,1.371 0.328,0.337 0.481,0.694 0.528,1.036 0.174,1.267 -0.983,2.831 -4.046,4.253 -3.348,1.554 -7.409,1.947 -10.215,1.635 l -0.983,-0.111 c -2.245,-0.302 -3.525,2.599 -2.178,4.586 0.868,1.281 3.233,2.114 5.599,2.115 5.425,0.001 9.595,-2.316 11.146,-4.317 l 0.124,-0.177 c 0.076,-0.115 0.013,-0.178 -0.082,-0.113 -1.267,0.867 -6.896,4.31 -12.917,3.274 0,0 -0.732,-0.12 -1.399,-0.38 -0.531,-0.206 -1.641,-0.717 -1.776,-1.857 4.859,1.503 7.918,0.082 7.918,0.082 l 0,-0.002 0,0 m -7.697,-0.909 0.001,0.001 0.001,0.002 -0.002,-0.004 0,10e-4 0,0 M 17.684,19.041 c 1.866,-2.157 4.164,-4.032 6.222,-5.085 0.071,-0.036 0.147,0.041 0.108,0.111 -0.163,0.296 -0.478,0.93 -0.578,1.41 -0.016,0.075 0.066,0.131 0.129,0.088 1.28,-0.873 3.508,-1.808 5.462,-1.928 0.084,-0.005 0.124,0.102 0.058,0.154 -0.297,0.228 -0.622,0.543 -0.859,0.862 -0.04,0.054 -0.002,0.132 0.065,0.133 1.372,0.01 3.306,0.49 4.566,1.197 0.085,0.048 0.025,0.213 -0.071,0.191 -1.907,-0.437 -5.029,-0.769 -8.272,0.022 -2.895,0.706 -5.105,1.796 -6.717,2.969 -0.081,0.059 -0.179,-0.048 -0.113,-0.125 l 0,0.001 0,0" id="path1398" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1400" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1402" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1404" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 179.982,24.112 c -2.79,0 -4.068,2.092 -4.624,3.283 -0.367,0.787 -0.349,1.018 -0.617,1.018 -0.388,0 -0.066,-0.632 0.108,-1.376 0.344,-1.464 0.082,-2.582 0.082,-2.582 l -3.976,0 0,19.079 5.427,0 0,-6.049 c 0.642,1.089 1.832,2.253 3.666,2.253 3.924,0 5.899,-3.321 5.899,-7.807 0,-5.085 -2.364,-7.821 -5.966,-7.821 l 0.001,0.002 0,0 m -1.49,12.085 c -1.245,0 -2.16,-1.578 -2.16,-3.778 0,-2.136 0.941,-3.777 2.117,-3.777 1.51,0 2.154,1.385 2.154,3.777 0,2.488 -0.593,3.778 -2.111,3.778 l 0,0" id="path1406" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1408" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1410" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 72.109,24.112 c -2.387,0 -3.568,1.879 -4.11,3.09 -0.303,0.677 -0.387,1.212 -0.633,1.212 -0.346,0 -0.098,-0.465 -0.381,-1.496 -0.373,-1.357 -1.495,-2.806 -3.881,-2.806 -2.508,0 -3.582,2.119 -4.091,3.283 -0.348,0.796 -0.349,1.018 -0.617,1.018 -0.388,0 -0.066,-0.632 0.108,-1.376 0.344,-1.464 0.082,-2.582 0.082,-2.582 l -3.976,0 0,14.95 5.427,0 0,-7.438 c 0,-1.467 0.614,-3.329 1.666,-3.329 1.215,0 1.459,0.934 1.459,2.662 l 0,8.109 5.449,0 0,-7.442 c 0,-1.306 0.533,-3.329 1.674,-3.329 1.232,0 1.451,1.311 1.451,2.662 l 0,8.105 5.351,0 0,-8.792 c 0,-3.902 -1.375,-6.503 -4.977,-6.503 l -0.001,0.002 m 92.114,0 c -2.387,0 -3.568,1.879 -4.11,3.09 -0.303,0.677 -0.387,1.212 -0.633,1.212 -0.346,0 -0.115,-0.591 -0.381,-1.496 -0.398,-1.35 -1.387,-2.806 -3.881,-2.806 -2.508,0 -3.582,2.119 -4.091,3.283 -0.348,0.796 -0.349,1.018 -0.617,1.018 -0.388,0 -0.066,-0.632 0.108,-1.376 0.344,-1.464 0.082,-2.582 0.082,-2.582 l -3.976,0 0,14.95 5.427,0 0,-7.438 c 0,-1.467 0.614,-3.329 1.666,-3.329 1.215,0 1.459,0.934 1.459,2.662 l 0,8.109 5.449,0 0,-7.442 c 0,-1.306 0.533,-3.329 1.674,-3.329 1.232,0 1.451,1.311 1.451,2.662 l 0,8.105 5.351,0 0,-8.792 c 0,-3.902 -1.375,-6.503 -4.977,-6.503 l -10e-4,0.002 m -77.871,0.003 c -4.157,0 -7.14,1.528 -7.14,1.528 l 0,4.493 c 0,0 3.294,-1.894 5.966,-1.894 2.133,0 2.395,1.15 2.298,2.105 0,0 -0.615,-0.163 -2.492,-0.163 -4.423,0 -6.656,2.01 -6.656,5.234 0,3.058 2.509,4.336 4.624,4.336 3.085,0 4.441,-2.073 4.858,-3.057 0.289,-0.682 0.342,-1.142 0.602,-1.142 0.296,0 0.196,0.33 0.182,1.009 -0.025,1.189 0.031,2.089 0.22,2.846 l 4.09,0 0,-7.358 c 0,-4.594 -1.625,-7.937 -6.551,-7.937 l -10e-4,0 0,0 m -1.321,11.797 c -1.298,0.3 -1.97,-0.1 -1.97,-0.96 0,-1.178 1.219,-1.65 2.958,-1.65 0.767,0 1.488,0.066 1.488,0.066 0,0.505 -1.095,2.226 -2.476,2.544 m 16.812,-15.982 5.427,0 0,19.48 -5.427,0 0,-19.48 0,0 m 11.4,12.004 c 0,-1.344 1.249,-2.567 3.541,-2.567 2.498,0 4.507,1.203 4.958,1.476 l 0,-5.2 c 0,0 -1.587,-1.528 -5.489,-1.528 -4.113,0 -7.538,2.407 -7.538,7.587 0,5.18 3.108,8.052 7.527,8.052 3.451,0 5.509,-1.896 5.509,-1.896 l 0,-4.939 c -0.651,0.364 -2.465,1.623 -4.942,1.623 -2.623,0 -3.567,-1.207 -3.567,-2.607 l 10e-4,-10e-4 0,0 m 19.493,-7.819 c -3.142,0 -4.337,2.977 -4.578,3.494 -0.241,0.517 -0.361,0.814 -0.558,0.808 -0.343,-0.011 -0.104,-0.635 0.03,-1.038 0.253,-0.763 0.788,-2.763 0.788,-5.223 0,-1.668 -0.226,-2.226 -0.226,-2.226 l -4.685,0 0,19.48 5.427,0 0,-7.438 c 0,-1.212 0.483,-3.329 1.851,-3.329 1.132,0 1.487,0.839 1.487,2.529 l 0,8.239 5.427,0 0,-7.913 c 0,-3.838 -0.636,-7.381 -4.963,-7.381 l 0,-0.002 0,0 m 6.727,0.361 0,14.933 5.427,0 0,-14.933 c 0,0 -0.912,0.534 -2.708,0.534 -1.796,0 -2.719,-0.534 -2.719,-0.534 l 0,0" id="path1412" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1414" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1416" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 145.483,21.947 c 0,1.1974 -1.487,2.168 -3.322,2.168 -1.835,0 -3.322,-0.9706 -3.322,-2.168 0,-1.1974 1.487,-2.168 3.322,-2.168 1.835,0 3.322,0.9706 3.322,2.168" id="path1418" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1420" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1422" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 94.659,24.476 0,14.933 5.427,0 0,-14.933 c 0,0 -0.912,0.534 -2.708,0.534 l -2.719,-0.534" id="path1424" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1426" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g transform="matrix(5.3778829,0,0,5.3778829,29.999029,-193.78588)" id="g1428" style="fill:#000000;fill-opacity:1;stroke:none">
+   <path vector-effect="none" d="m 100.679,21.947 c 0,1.1974 -1.4873,2.168 -3.322,2.168 -1.8347,0 -3.322,-0.9706 -3.322,-2.168 0,-1.1974 1.4873,-2.168 3.322,-2.168 1.8347,0 3.322,0.9706 3.322,2.168" id="path1430" inkscape:connector-curvature="0" style="fill-rule:nonzero">
+   </path>
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1432" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1434" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1436" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1438" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1440" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(30,47)" id="g1442" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(30,47)" id="g1444" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1446" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1448" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1450" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1452" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1454" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="matrix(0.999942,0,0,0.999942,30,47.0017)" id="g1456" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1458" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1460" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" transform="translate(30,47)" id="g1462" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1464" style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1514" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1516" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+  <g stroke-miterlimit="2" id="g1518" style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-opacity:1">
+  </g>
+ </g>
+</svg>

--- a/src/content/programs/mailchimp/free-plan.yaml
+++ b/src/content/programs/mailchimp/free-plan.yaml
@@ -1,0 +1,53 @@
+provider_slug: "mailchimp"
+title: "Mailchimp Free Plan"
+meta_title: "Mailchimp Free Plan - Free Email Marketing for 500 Contacts"
+intro: "Free forever email marketing plan with up to 500 contacts and 1,000 monthly email sends, perfect for small businesses and startups"
+description: "Mailchimp's Free Plan provides essential email marketing tools for small businesses and startups at no cost. The plan includes basic email campaigns, templates, signup forms, one landing page, limited automation, and basic reporting. Ideal for businesses with up to 500 contacts who send up to 1,000 emails per month. While it includes Mailchimp branding and has limited features compared to paid plans, it offers a solid foundation for email marketing without any time restrictions."
+status: "Active"
+url: "https://mailchimp.com/pricing/"
+min_value: 0
+max_value: 0
+value_type: "credits"
+currency: "USD"
+tags: ["email", "marketing", "free trial", "automation", "analytics"]
+date: 2025-01-15
+
+tiers:
+  - name: "Free Plan"
+    intro: "Forever free email marketing with essential features for small businesses"
+    max_value: 0
+    url: "https://mailchimp.com/pricing/"
+    benefits:
+      - "Up to 500 contacts and 1,000 monthly email sends"
+      - "Basic email campaigns and templates"
+      - "1 landing page and signup forms"
+      - "Limited automation and A/B testing"
+      - "Essential analytics and email support"
+    benefits_level: 1
+    duration: ["Forever"]
+    eligibility:
+      - "Available to anyone (individuals, small businesses, nonprofits)"
+      - "Valid email address required"
+      - "Must comply with Mailchimp's Terms of Service"
+      - "Must follow anti-spam policies"
+    effort_level: 1
+    timeline_indication: "Immediate activation"
+    steps_to_apply:
+      - name: "Sign Up"
+        description: "Create a free Mailchimp account"
+        action: "Sign Up Free"
+        action_url: "https://mailchimp.com/pricing/"
+
+faq:
+  - question: "What happens when I reach 500 contacts?"
+    answer: "Once you reach 500 contacts, you cannot add new contacts until you remove existing ones or upgrade to a paid plan. Existing contacts remain accessible and you can continue using other features."
+  - question: "What happens if I exceed 1,000 monthly emails?"
+    answer: "You cannot send new campaigns until the next month or until you upgrade to a paid plan. Scheduled campaigns may be paused, but your account and previous data remain accessible."
+  - question: "Can I remove Mailchimp branding from emails?"
+    answer: "No, the Free Plan includes 'Powered by Mailchimp' branding in all emails. You need to upgrade to a paid plan to remove this branding."
+  - question: "Is there a time limit on the Free Plan?"
+    answer: "No, the Free Plan is available forever with no time restrictions. It's not a trial - it's a permanent free tier."
+  - question: "What support is available on the Free Plan?"
+    answer: "Free Plan users have access to email support only. Phone and chat support are available with paid plans."
+  - question: "Can I upgrade anytime?"
+    answer: "Yes, you can upgrade to any paid plan at any time directly from your account dashboard. Your data and contacts will be preserved during the upgrade."

--- a/src/content/providers/mailchimp.yaml
+++ b/src/content/providers/mailchimp.yaml
@@ -1,0 +1,13 @@
+active: true
+name: "Mailchimp"
+short_name: "Mailchimp"
+slug: "mailchimp"
+url: "https://mailchimp.com"
+color: "#007c89"
+best_deal: "Free forever plan for up to 500 contacts"
+intro: "All-in-one email marketing platform helping businesses grow with automated campaigns, audience insights, and personalized content."
+video: ""
+tags:
+  - "email"
+  - "marketing"
+  - "automation"


### PR DESCRIPTION
Add Mailchimp as a new provider with their free forever plan offering:

- Up to 500 contacts and 1,000 monthly email sends
- Basic email campaigns, templates, and signup forms
- 1 landing page and limited automation
- Forever free with no time restrictions
- Essential features for small businesses and startups

Closes #367

Generated with [Claude Code](https://claude.ai/code)