### PR TITLE
Update TikTok Ads Manager credits to 6k max

### DIFF
--- a/src/content/programs/tiktok/tiktok-ads-manager-welcome-gift.yaml
+++ b/src/content/programs/tiktok/tiktok-ads-manager-welcome-gift.yaml
@@ -4,19 +4,19 @@ title: TikTok Ads Manager Welcome Gift
 meta_title: TikTok Ads Manager Welcome Gift - Unlock Matching Ad Credits
 intro: >-
   New advertisers using TikTok Ads Manager can receive a matching ad credit
-  welcome gift of up to $1,500 by spending the corresponding amount on their
+  welcome gift of up to $6,000 by spending the corresponding amount on their
   first ad campaign within a 30-day window.
 description: >-
   TikTok's Ads Manager Welcome Gift program offers new advertisers a lucrative
   opportunity to kickstart their campaigns with dollar-for-dollar matched
   credits. Unlock benefits through tiered spending thresholds: spend $100 to
-  receive $100, $500 to receive $500, and $1,500 to receive $1,500. After a new
-  account registration, participants have a 30-day redemption period to reach
-  their desired tier, with credits applied 1-7 days after meeting spending
-  requirements. The program integrates organic and paid strategies, such as
-  Spark Ads, to maximize campaign impact. Eligibility is limited to new TikTok
-  Ads Manager accounts in selected regions, and all credits expire on February
-  28, 2025.
+  receive $100, $500 to receive $500, $1,500 to receive $1,500, or scale up to
+  $6,000 in matched credit by spending $6,000. After registering a new account,
+  participants have a 30-day redemption period to reach their desired tier, with
+  credits applied 1-7 days after meeting spending requirements. The program
+  integrates organic and paid strategies, such as Spark Ads, to maximize
+  campaign impact, and is limited to new TikTok Ads Manager accounts in selected
+  regions.
 status: Active
 tags:
   - advertising
@@ -26,7 +26,7 @@ url: https://ads.tiktok.com
 value_type: credits
 currency: USD
 min_value: 100
-max_value: 1500
+max_value: 6000
 community_notes:
   - title: Geo Availability
     body: >-
@@ -120,14 +120,49 @@ tiers:
           credit.
         action: Start Campaign
         action_url: https://ads.tiktok.com
+  - name: Scale Tier
+    intro: >-
+      Unlock the maximum $6,000 matched credit by investing $6,000 in your first
+      30 days of advertising.
+    max_value: 6000
+    url: https://ads.tiktok.com
+    benefits:
+      - $6,000 ad credit match
+      - Priority optimization insights and account guidance
+      - Maximum budget boost for rapid scaling
+    benefits_level: 3
+    duration:
+      - 30 days redemption period
+    eligibility:
+      - New TikTok Ads Manager account
+      - Minimum spend of $6,000
+    effort_level: 3
+    steps_to_apply:
+      - name: Register for TikTok Ads Manager
+        description: >-
+          Sign up for a new TikTok Ads Manager account to unlock access to the
+          full welcome gift.
+        action: Sign Up
+        action_url: https://ads.tiktok.com
+      - name: Launch Ad Campaign
+        description: >-
+          Run campaigns spending at least $6,000 within the first 30 days to
+          receive the maximum matched credit.
+        action: Start Campaign
+        action_url: https://ads.tiktok.com
 faq:
   - question: Can I combine this welcome gift with other offers?
     answer: >-
       No, this is a standalone welcome offer exclusively for new TikTok Ads
       Manager accounts.
+  - question: How much matched credit can I receive?
+    answer: >-
+      Eligible new accounts can unlock matched ad credits ranging from $100 up
+      to $6,000, depending on how much they spend within the 30-day redemption
+      window.
   - question: What happens if I don't use all the credits?
     answer: >-
-      Unused credits expire on February 28, 2025, regardless of account
-      activity.
+      Unused credits will expire according to the expiration date listed in the
+      Promotions Center of your TikTok Ads Manager account.
   - question: Is there a minimum spend requirement after claiming the credits?
     answer: Yes, you must maintain an active campaign to retain the ad credits.


### PR DESCRIPTION
## Summary
- update the TikTok Ads Manager Welcome Gift content to reflect the new $6,000 matched credit maximum for new accounts
- add a scale tier describing the $6,000 spend requirement and refreshed FAQ/details to align with the latest offer wording

## Testing
- pnpm check *(fails: existing TypeScript errors in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68d0dbaf9ef083339bde30c059b7c40f